### PR TITLE
Add AI Projects Table and Display Page

### DIFF
--- a/src/app/api/kelly/route.ts
+++ b/src/app/api/kelly/route.ts
@@ -1,0 +1,8 @@
+import { db } from "@/server/db";
+import { aiProjects } from "@/server/db/schema";
+import { NextResponse } from "next/server";
+
+export async function GET () {
+    const fetchedAiProjects = await db.select().from(aiProjects);
+    return NextResponse.json(fetchedAiProjects);
+}

--- a/src/app/kelly/page.tsx
+++ b/src/app/kelly/page.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { type AiProject } from "@/server/db/schema";
+import Link from "next/link";
+
+export default function KellyPage() {
+    // Declared my state variable to store the AI projects returned from the API
+    const [aiProjects, setAiProjects] = useState<AiProject[]>([]);
+
+    // UseEffect to fetch the AI projects from the API
+    useEffect(() => {
+        fetch("/api/kelly")
+            .then(res => res.json())
+            // And then updating the state variable with the data fetched
+            .then(data => setAiProjects(data));
+    }, []);
+    return <div className="flex flex-col gap-4">
+        <h1>Team&apos;s AI Projects</h1>
+        {/* Mapping over the AI projects and displaying the data */}
+        {aiProjects.map((aiProject) => (
+            <div key={aiProject.id} className="border-2 border-gray-300 p-4 rounded-md">
+                <h2>{aiProject.name}</h2>
+                <p>{aiProject.description}</p>
+                {/* Mapping over the stack and displaying only the name of the stack comma separated */}
+                <p>{aiProject.stack?.map((stack) => stack.name).join(", ")}</p>
+                <p>{aiProject.status}</p>
+                {/* Here, I am conditionally displaying the repository as a link if it exists */}
+                {aiProject.repository && <p><Link href={aiProject.repository} target="_blank" rel="noopener noreferrer">{aiProject.repository}</Link></p>}
+            </div>
+        ))}
+    </div>;
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, integer, text, timestamp, boolean, serial, varchar } from "drizzle-orm/pg-core";
+import { pgTable, text, timestamp, boolean, serial, varchar, jsonb } from "drizzle-orm/pg-core";
 
 export const tasks = pgTable("tasks", {
   id: serial("id").primaryKey(),
@@ -10,5 +10,30 @@ export const tasks = pgTable("tasks", {
   updatedAt: timestamp("updated_at").notNull().defaultNow()
 })
 
+export const aiProjects = pgTable("ai_projects", {
+  id: serial("id").primaryKey(),
+  name: varchar("name", { length: 250 }).notNull(),
+  description: text("description"),
+  stack: jsonb("stack"),
+  status: text("status"),
+  repository: text("repository"),
+  createdAt: timestamp("created_at").notNull().defaultNow(),
+  updatedAt: timestamp("updated_at").notNull().defaultNow()
+})
+
+export interface StackItem {
+  name: string;
+  version?: string;
+  category?: string;
+}
+
 export type Task = typeof tasks.$inferSelect;
 export type InsertTask = typeof tasks.$inferInsert;
+
+// Overriding the stack type to use the interface so TypeScript knows what the stack is
+export type AiProject = Omit<typeof aiProjects.$inferSelect, 'stack'> & {
+  stack: StackItem[] | null;
+};
+export type InsertAiProject = Omit<typeof aiProjects.$inferInsert, 'stack'> & {
+  stack: StackItem[] | null;
+};


### PR DESCRIPTION
## Overview
This PR adds a new `ai_projects` table to track the team's AI projects, along with an API endpoint and frontend page to display them.

## Changes Made

### Database Schema (`src/server/db/schema.ts`)
- Added `aiProjects` table with the following fields:
  - `id`: Primary key
  - `name`: Project name (max 250 characters)
  - `description`: Detailed project description
  - `stack`: JSONB field storing an array of technologies used
  - `status`: Current project status
  - `repository`: GitHub repository URL
  - `createdAt` / `updatedAt`: Timestamps

- Created `StackItem` interface to define the structure of technology stack items
- Added `AiProject` and `InsertAiProject` types with type overrides for the JSONB `stack` field

### API Endpoint (`src/app/api/kelly/route.ts`)
- Created GET endpoint that fetches all AI projects from the database
- Returns JSON array of projects

### Frontend Page (`src/app/kelly/page.tsx`)
- Built display page that fetches and renders AI projects
- Shows project name, description, tech stack (comma-separated), status, and (conditionally) repository link
- Repository links open in new tab

## Screenshots
Page with AI projects displayed:
<img width="1058" height="825" alt="image" src="https://github.com/user-attachments/assets/68ac6e90-9967-424d-aa4e-77c91bca2aa2" />
Drizzle Studio for entering data:
<img width="1917" height="582" alt="image" src="https://github.com/user-attachments/assets/17af1832-5ee3-4f88-b0dc-4654ca84e643" />


## Notes
- Heavily commented code to serve as a reference for team members
- Used JSONB for flexible stack storage to accommodate varying technologies
- Followed the same pattern as the tasks table for consistency